### PR TITLE
refactor(ts): use namespace instead of module

### DIFF
--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -110,7 +110,7 @@ import { Content, IContent, ODataApi, ContentTypes } from 'sn-client-js';
  * const store = Store.configureStore(myReducer);
  * ```
  */
-export module Actions {
+export namespace Actions {
     /**
      * Action creator for intializing a sensenet store.
      * @param path {string} Path of the root Content

--- a/src/Epics.ts
+++ b/src/Epics.ts
@@ -36,7 +36,7 @@ import 'rxjs/add/operator/catch'
  * ```
  */
 
-export module Epics {
+export namespace Epics {
     /**
      * Epic for initialize a sensenet Redux store. It checks the InitSensenetStore Action and calls the necessary ones snycronously. Loads the current content,
      * checks the login state with CheckLoginState, fetch the children items with RequestContent and loads the current content related actions with

--- a/src/Reducers.ts
+++ b/src/Reducers.ts
@@ -9,7 +9,7 @@ import { Authentication } from 'sn-client-js';
  * Following module contains the reducers of sn-redux, some 'reducer groups' and the root reducer which could be passed to the store creator function. Using a root reduces means
  * that you define which combination of reducers will be used and eventually defines which type of actions can be called on the store.
  */
-export module Reducers {
+export namespace Reducers {
     /**
        * Reducer to handle Actions on the country property in the session object.
        * @param {Object} [state=''] Represents the current state.

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -38,7 +38,7 @@ import { schema } from 'normalizr';
  *
  * ![Normalized content](http://download.sensenet.com/aniko/sn7/jsapidocs/img/normalized-content.png)
 */
-export module Schemas {
+export namespace Schemas {
     /**
      * Schema of a Content.
      *

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -32,7 +32,7 @@ import { Repository } from 'sn-client-js';
  * );
  * ```
  */
-export module Store {
+export namespace Store {
 
     /**
      * Method to create a Redux store that holds the application state.


### PR DESCRIPTION
The internal 'module' syntax is deprecated, use the 'namespace' keyword instead.